### PR TITLE
refactor(ttd): add dot_product helper

### DIFF
--- a/src/numpy_ttd/_helpers.py
+++ b/src/numpy_ttd/_helpers.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable, Reversible
 
 import numpy as np
 
-from numpy_ttd.math import qr_rows
+from numpy_ttd.math import dot_product, qr_rows
 from numpy_ttd.types import Core
 
 
@@ -24,4 +24,4 @@ def orthogonalize_right[DType: np.floating](cores: list[Core[DType]]) -> None:
         cores[k - 1] = q.reshape((-1, i_k, beta_k))
         # 𝐆ₖ₋₁ := 𝐆ₖ₋₁ ×₃ 𝐑
         # NOTE: there is a typo in the TTD paper: it incorrectly says 𝐆ₖ ×₃ 𝐑
-        cores[k - 2] = np.einsum("ijk,kl", cores[k - 2], r)
+        cores[k - 2] = dot_product(cores[k - 2], r)

--- a/src/numpy_ttd/math.py
+++ b/src/numpy_ttd/math.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -107,3 +107,38 @@ def qr_rows[DT: np.floating](matrix: Matrix[DT]) -> tuple[Matrix[DT], Matrix[DT]
     q, r = np.linalg.qr(matrix.T)
 
     return q.T, r.T
+
+
+@overload
+def dot_product[DT: np.dtype, A: int, B: int, C: int](
+    a: np.ndarray[tuple[A, B], DT],
+    b: np.ndarray[tuple[B, C], DT],
+) -> np.ndarray[tuple[A, C], DT]: ...
+
+
+@overload
+def dot_product[DT: np.dtype, A: int, B: int, C: int, D: int](
+    a: np.ndarray[tuple[A, B, C], DT],
+    b: np.ndarray[tuple[C, D], DT],
+) -> np.ndarray[tuple[A, B, D], DT]: ...
+
+
+@overload
+def dot_product[DT: np.dtype, A: int, B: int, C: int, D: int](
+    a: np.ndarray[tuple[A, B], DT],
+    b: np.ndarray[tuple[B, C, D], DT],
+) -> np.ndarray[tuple[A, C, D], DT]: ...
+
+
+@overload
+def dot_product[DT: np.dtype, A: int, B: int, C: int, D: int, E: int](
+    a: np.ndarray[tuple[A, B, C], DT],
+    b: np.ndarray[tuple[C, D, E], DT],
+) -> np.ndarray[tuple[A, B, D, E], DT]: ...
+
+
+def dot_product[DT: np.dtype](
+    a: np.ndarray[tuple[int, ...], DT], b: np.ndarray[tuple[int, ...], DT]
+) -> np.ndarray[tuple[int, ...], DT]:
+    """Compute the tensor dot product."""
+    return cast(np.ndarray[tuple[int, ...], DT], np.tensordot(a, b, axes=1))

--- a/src/numpy_ttd/ops.py
+++ b/src/numpy_ttd/ops.py
@@ -12,9 +12,10 @@ from numpy_ttd._numpy_api import implements_function, implements_ufunc
 from numpy_ttd.math import (
     DEFAULT_EPSILON,
     delta_truncated_svd,
+    dot_product,
     truncation_parameter,
 )
-from numpy_ttd.types import Core, Matrix, NDArray
+from numpy_ttd.types import Core, Matrix
 
 if TYPE_CHECKING:
     from numpy_ttd.ttd import TTD
@@ -443,9 +444,9 @@ def _tensordot_transposed[DType: np.floating](
     # multiply the message_matrix into either the first free b core or the last
     # free a core
     if b_free:
-        out_cores[len(a_free)] = np.einsum("ab,bcd", message_matrix, b_free[0])
+        out_cores[len(a_free)] = dot_product(message_matrix, b_free[0])
     else:
-        out_cores[-1] = np.einsum("abc,cd", a_free[-1], message_matrix)
+        out_cores[-1] = dot_product(a_free[-1], message_matrix)
 
     return TTD(out_cores, dtype=dtype)
 
@@ -597,7 +598,7 @@ def transpose[DType: np.floating](
             r0, n1, r1 = core.shape
             q, r = np.linalg.qr(core.reshape((r0 * n1, r1)))
             cores[i] = q.reshape((r0, n1, -1))
-            cores[i + 1] = np.einsum("jkl,ji", cores[i + 1], r)
+            cores[i + 1] = dot_product(r, cores[i + 1])
 
         # Swap cores
         core_0 = cores[k]
@@ -607,9 +608,7 @@ def transpose[DType: np.floating](
 
         assert r1 == r1b, f"Internal rank mismatch: {r1} != {r1b}"
 
-        merged = cast(NDArray[DType], np.einsum("ajk,kiz", core_0, core_1)).reshape(
-            (r0 * n2, n1 * r2)
-        )
+        merged = dot_product(core_0, core_1).swapaxes(1, 2).reshape((r0 * n2, n1 * r2))
         u, s, v_t = delta_truncated_svd(merged, delta)
 
         r1_new = len(s)
@@ -739,12 +738,8 @@ def get_item[DType: np.floating](
             continue
 
         # merge the slice of the core and the message matrix
-        cores.append(
-            cast(
-                Core[DType],
-                np.einsum("ij,jkl", message_matrix, core[:, index, :]),
-            )
-        )
+        core_slice: Core[DType] = core[:, index, :]
+        cores.append(dot_product(message_matrix, core_slice))
         # continue with a clean new message matrix
         message_matrix = np.eye(core.shape[2], dtype=ttd.dtype)
 
@@ -757,9 +752,9 @@ def get_item[DType: np.floating](
     # merge the message matrix into either the first remaining core or the last
     # preserved core
     if remaining:
-        remaining[0] = np.einsum("ij,jkl", message_matrix, remaining[0])
+        remaining[0] = dot_product(message_matrix, remaining[0])
         cores.extend(remaining)
     else:
-        cores[-1] = np.einsum("ijk,kl", cores[-1], message_matrix)
+        cores[-1] = dot_product(cores[-1], message_matrix)
 
     return TTD(cores, dtype=ttd.dtype)

--- a/src/numpy_ttd/ttd.py
+++ b/src/numpy_ttd/ttd.py
@@ -14,6 +14,7 @@ from numpy_ttd._numpy_api import HANDLED_FUNCTIONS, HANDLED_UFUNCS
 from numpy_ttd.math import (
     DEFAULT_EPSILON,
     delta_truncated_svd,
+    dot_product,
     truncation_parameter,
 )
 from numpy_ttd.types import Core, Matrix, NDArray
@@ -271,15 +272,8 @@ class TTD[DType: np.floating](NDArrayOperatorsMixin, Sequence["TTD[DType]" | DTy
             u, s, v_t = delta_truncated_svd(core.reshape(beta_k1 * i_k, beta_k), delta)
             # 𝐆ₖ(βₖ₋₁; iₖγₖ) = 𝐔
             cores[k - 1] = u.reshape((beta_k1, i_k, -1))
-            # 𝐆ₖ₊₁ := 𝐆ₖ₊₁ ×₁ (𝐕𝚲)ᵀ
-            cores[k] = np.einsum(
-                "ijk,hi,h->hjk",
-                cores[k],
-                v_t,
-                s,
-                # in 99% of cases, this is the optimal path
-                optimize=("einsum_path", (0, 1), (0, 1)),
-            )
+            # 𝐆ₖ₊₁ := 𝐆ₖ₊₁ ×₁ (𝐕𝚲)ᵀ = 𝐕𝚲 ⋅ 𝐆ₖ₊₁
+            cores[k] = dot_product(np.multiply(s, v_t), cores[k])
 
     def rounded(self, epsilon: DType | float = DEFAULT_EPSILON) -> TTD[DType]:
         """Return a new rounded TTD object."""


### PR DESCRIPTION
Basically a `tensordot`/`einsum` replacement with a more useful defaults and better typing – it saves a bunch of casts and more strictly validates arguments.

Also, I know that it is slightly stylistic/opinionated, so I don't mind not merging this.