### PR TITLE
fix(ttd): correct isinstance types and order

### DIFF
--- a/src/numpy_ttd/ttd.py
+++ b/src/numpy_ttd/ttd.py
@@ -418,14 +418,14 @@ class TTD[DType: np.floating](NDArrayOperatorsMixin, Sequence["TTD[DType]" | DTy
         | Sequence[SupportsIndex | slice[SupportsIndex | None]],
     ) -> TTD[DType] | DType:
         """Index into the TTD object."""
-        if key == Ellipsis:
+        if key is Ellipsis:
             return self.copy()
 
-        if isinstance(key, tuple):
-            return ops.get_item(self, key)
-
-        if isinstance(key, (int, slice)):
+        if isinstance(key, (SupportsIndex, slice)):
             return ops.get_item(self, (key,))
+
+        if isinstance(key, Sequence):
+            return ops.get_item(self, key)
 
         raise NotImplementedError
 


### PR DESCRIPTION
In theory, a `Sequence` may also implement `SupportsIndex` in which case, we probably want to use it in that sense. (Also it appeases some type checkers like `ty`.)