### PR TITLE
refactor(ttd): ignore PLC0415 file-wide

### DIFF
--- a/src/numpy_ttd/ops.py
+++ b/src/numpy_ttd/ops.py
@@ -785,7 +785,7 @@ def gradient[DType: np.floating](
         default 1.
 
     """
-    from numpy_ttd.ttd import TTD  # noqa: PLC0415
+    from numpy_ttd.ttd import TTD
 
     if axis is None:
         axes = tuple(range(ttd.ndim))

--- a/src/numpy_ttd/ops.py
+++ b/src/numpy_ttd/ops.py
@@ -1,3 +1,4 @@
+# ruff: noqa: PLC0415
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
@@ -54,7 +55,7 @@ def add[DType: np.floating](
 
     """
     # the import has to be here to avoid circular imports
-    from numpy_ttd.ttd import TTD  # noqa: PLC0415
+    from numpy_ttd.ttd import TTD
 
     if a.shape != b.shape:
         raise ValueError("Tensors with different shapes cannot be added.")
@@ -182,7 +183,7 @@ def multiply[DType: np.floating](
         The result of the multiplication.
 
     """
-    from numpy_ttd.ttd import TTD  # noqa: PLC0415
+    from numpy_ttd.ttd import TTD
 
     def impl(
         ttd: TTD[DType], scalar: np.floating | float, out: TTD[DType] | None = None
@@ -367,7 +368,7 @@ def tensordot[DType: np.floating](
         TT tensor over uncontracted modes (a_free then b_free) or scalar.
 
     """
-    from numpy_ttd.ttd import TTD  # noqa: PLC0415
+    from numpy_ttd.ttd import TTD
 
     if a.dtype != b.dtype:
         raise ValueError("TTD objects must have the same dtype")
@@ -423,7 +424,7 @@ def tensordot[DType: np.floating](
 def _tensordot_transposed[DType: np.floating](
     a: TTD[DType], b: TTD[DType], k: int, dtype: np.dtype[DType]
 ) -> TTD[DType] | DType:
-    from numpy_ttd.ttd import TTD  # noqa: PLC0415
+    from numpy_ttd.ttd import TTD
 
     assert a.ndim >= k, "k must be <= a.ndim"
     assert b.ndim >= k, "k must be <= b.ndim"
@@ -550,7 +551,7 @@ def transpose[DType: np.floating](
         Transposed TT tensor.
 
     """
-    from numpy_ttd.ttd import TTD  # noqa: PLC0415
+    from numpy_ttd.ttd import TTD
 
     d = ttd.ndim
 
@@ -650,7 +651,7 @@ def stack[DType: np.floating](ttds: Sequence[TTD[DType]], axis: int = 0) -> TTD[
         The stacked TTD.
 
     """
-    from numpy_ttd.ttd import TTD  # noqa: PLC0415
+    from numpy_ttd.ttd import TTD
 
     if isinstance(ttds, TTD) and ttds.ndim == 1:
         return cast(TTD[DType], ttds)
@@ -721,7 +722,7 @@ def get_item[DType: np.floating](
         The indexed TTD or a scalar value.
 
     """
-    from numpy_ttd.ttd import TTD  # noqa: PLC0415
+    from numpy_ttd.ttd import TTD
 
     if len(indexes) == 0:
         raise IndexError("Cannot index with an empty tuple")


### PR DESCRIPTION
Felt rather silly adding it there every time... It may be better if there was a way to not have to do this, but I don't know how.